### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -1,4 +1,6 @@
 name: "Pull Request Workflow"
+permissions:
+  contents: read
 on:
   pull_request:
     # The specific activity types are listed here to include "labeled" and "unlabeled"


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/analysis-for-action/security/code-scanning/2](https://github.com/ONSdigital/analysis-for-action/security/code-scanning/2)

To fix this issue, explicitly set the permissions at the root of the workflow file, or within the job which CodeQL highlighted. Since in this workflow there is only one job, setting it at the root applies to the entire workflow and is the simplest/clearest solution. The minimum viable permission for a linting/pre-commit job is typically `contents: read` (read-only source code), as the workflow only pulls code— it doesn't need to write to the repository, modify issues, etc. Add a block like:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:` or before the `on:` or `jobs:` keys. This makes it clear to GitHub Actions what the token is allowed to do and restricts it appropriately. No functional change will occur to the workflow, but security will be improved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
